### PR TITLE
Read the entire subtitle file in when determing the encoding

### DIFF
--- a/subaligner/utils.py
+++ b/subaligner/utils.py
@@ -407,7 +407,7 @@ class Utils(object):
         """
 
         with open(subtitle_file_path, "rb") as file:
-            raw = b"".join([file.readline() for _ in range(10)])
+            raw = b"".join(file.readlines())
 
         detected = cchardet.detect(raw)
         detected = detected or {}


### PR DESCRIPTION
Previously only 10 lines were read and this could cause issues as
Unicode characters may only appear after 10 lines and then a failure
would occur.